### PR TITLE
Fix catching the M+ start event in unknown M+ dungeons

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -32,9 +32,6 @@ local function ShowPrompt(zone, diff)
 		}
 	end
 	StaticPopup_Show("LoggerHeadLiteLogConfirm", ("%s %s"):format(diff, zone))
-	if diff == 8 then -- catch the m+ start event
-		LoggingCombat(true)
-	end
 end
 
 function addon:OnInitialize()
@@ -75,6 +72,9 @@ function addon:CheckInstance(override)
 		if db.zones[areaID][difficulty] == nil then
 			if db.prompt then
 				ShowPrompt(zoneName, difficultyName)
+				if difficulty == 8 then -- catch the m+ start event
+					LoggingCombat(true)
+				end
 				return
 			else
 				db.zones[areaID][difficulty] = false


### PR DESCRIPTION
The condition was ineffectual in ShowPrompt, because the difficultyName was being passed in, and not the index. Moving it out of ShowPrompt should ensure its always functional, and properly catches the start event in all cases.